### PR TITLE
Adding scroll listeners to all element's parents

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,9 @@
     "visibility",
     "mixin"
   ],
+  "dependencies": {
+    "react": "~0.13"
+  },
   "license": "MIT",
   "ignore": [
     "**/.*",

--- a/index.js
+++ b/index.js
@@ -1,4 +1,14 @@
 (function() {
+  if (typeof window === "undefined") {
+    return console.error("This environment lacks 'window' support.");
+  }
+
+  if (typeof document === "undefined") {
+    return console.error("This environment lacks 'document' support.");
+  }
+
+  var React = window.React || require('react');
+
   var RATE_LIMIT = 25;
 
   var ComponentVisibilityMixin = {
@@ -25,7 +35,7 @@
      * on opacity:0 or visibility:hidden.
      */
     checkComponentVisibility: function() {
-      var domnode = this.getDOMNode(),
+      var domnode = this._dom_node,
           gcs = getComputedStyle(domnode, false),
           dims = domnode.getBoundingClientRect(),
           h = window.innerHeight,
@@ -75,7 +85,10 @@
      * immediately check whether this element is already visible or not.
      */
     enableVisbilityHandling: function(checkNow) {
-      var domnode = this.getDOMNode();
+      if (!this._dom_node) {
+        this._dom_node = React.findDOMNode(this);
+      }
+      var domnode = this._dom_node;
 
       this._rcv_fn = function() {
         if(this._rcv_lock) {

--- a/index.js
+++ b/index.js
@@ -127,6 +127,14 @@
      */
     disableVisbilityHandling: function() {
       if (this._rcv_fn) {
+        var domnode = this._dom_node;
+
+        while (domnode.nodeName !== 'BODY' && domnode.parentElement) {
+          domnode = domnode.parentElement;
+          domnode.removeEventListener("scroll", this._rcv_fn);
+        }
+
+        document.removeEventListener("visibilitychange", this._rcv_fn);
         document.removeEventListener("scroll", this._rcv_fn);
         window.removeEventListener("resize", this._rcv_fn);
         this._rcv_fn = false;

--- a/index.js
+++ b/index.js
@@ -75,6 +75,8 @@
      * immediately check whether this element is already visible or not.
      */
     enableVisbilityHandling: function(checkNow) {
+      var domnode = this.getDOMNode();
+
       this._rcv_fn = function() {
         if(this._rcv_lock) {
           this._rcv_schedule = true;
@@ -90,9 +92,17 @@
           }
         }.bind(this), RATE_LIMIT);
       }.bind(this);
+
+      /* Adding scroll listeners to all element's parents */
+      while (domnode.nodeName !== 'BODY' && domnode.parentElement) {
+        domnode = domnode.parentElement;
+        domnode.addEventListener("scroll", this._rcv_fn);
+      }
+      /* Adding listeners to page events */
       document.addEventListener("visibilitychange", this._rcv_fn);
       document.addEventListener("scroll", this._rcv_fn);
       window.addEventListener("resize", this._rcv_fn);
+
       if (checkNow) { this._rcv_fn(); }
     },
 

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "bugs": {
     "url": "https://github.com/Pomax/react-component-visibility/issues"
   },
-  "homepage": "https://github.com/Pomax/react-component-visibility"
+  "homepage": "https://github.com/Pomax/react-component-visibility",
+  "peerDependencies": {
+    "react": "^0.13"
+  }
 }


### PR DESCRIPTION
@Pomax hello my friend! Nice to write you again :) this is not the change I was talking about previous time but should be very useful. In my case I have scrollable DIV. And when I scroll through this DIV visibility status was not updating on it's children nodes. Now it's fixed.
