### PR TITLE
Fix import when React is not attached to window

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 (function() {
-  var React = (typeof window !== 'undefined') ? window.React : require('react');
-  var ReactDOM = (typeof window !== 'undefined') ? window.ReactDOM : require('react-dom');
+  var React = (typeof window !== 'undefined' && window.React) ? window.React : require('react');
+  var ReactDOM = (typeof window !== 'undefined' && window.ReactDOM) ? window.ReactDOM : require('react-dom');
 
   var RATE_LIMIT = 25;
 


### PR DESCRIPTION
Hello again :)

I was updating my app which was using `react-component-visibility` to `react 0.14` so I needed to update this cool library. But, unfortunately, it didn't work out of the box because I don't have React & ReactDOM attached to `window`, I use ES6 with webpack and nothing is exposed to window. This patch fixes the problem for me.

@Pomax WDYT?

Thanks
